### PR TITLE
Fix crash at strlcpy on macos

### DIFF
--- a/telescope.c
+++ b/telescope.c
@@ -638,7 +638,7 @@ load_gemini_url(struct tab *tab, const char *url)
 
 	memset(&req, 0, sizeof(req));
 	strlcpy(req.host, tab->uri.host, sizeof(req.host));
-	strlcpy(req.port, tab->uri.port, sizeof(req.host));
+	strlcpy(req.port, tab->uri.port, sizeof(req.port));
 
 	return make_request(tab, &req, PROTO_GEMINI, tab->hist_cur->h);
 }
@@ -681,7 +681,7 @@ load_gopher_url(struct tab *tab, const char *url)
 
 	memset(&req, 0, sizeof(req));
 	strlcpy(req.host, tab->uri.host, sizeof(req.host));
-	strlcpy(req.port, tab->uri.port, sizeof(req.host));
+	strlcpy(req.port, tab->uri.port, sizeof(req.port));
 
 	path = gopher_skip_selector(tab->uri.path, &type);
 	switch (type) {
@@ -715,7 +715,7 @@ load_via_proxy(struct tab *tab, const char *url, struct proxy *p)
 
 	memset(&req, 0, sizeof(req));
 	strlcpy(req.host, p->host, sizeof(req.host));
-	strlcpy(req.port, p->port, sizeof(req.host));
+	strlcpy(req.port, p->port, sizeof(req.port));
 
 	tab->proxy = p;
 
@@ -767,7 +767,7 @@ gopher_send_search_req(struct tab *tab, const char *text)
 
 	memset(&req, 0, sizeof(req));
 	strlcpy(req.host, tab->uri.host, sizeof(req.host));
-	strlcpy(req.port, tab->uri.port, sizeof(req.host));
+	strlcpy(req.port, tab->uri.port, sizeof(req.port));
 
 	/* +2 to skip /7 */
 	strlcpy(req.req, tab->uri.path+2, sizeof(req.req));


### PR DESCRIPTION
```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fff70fddb66 __pthread_kill + 10
1   libsystem_pthread.dylib       	0x00007fff711a8080 pthread_kill + 333
2   libsystem_c.dylib             	0x00007fff70f391ae abort + 127
3   libsystem_c.dylib             	0x00007fff70f39321 abort_report_np + 177
4   libsystem_c.dylib             	0x00007fff70f5dbf5 __chk_fail + 48
5   libsystem_c.dylib             	0x00007fff70f5dbc5 __chk_fail_overflow + 16
6   libsystem_c.dylib             	0x00007fff70f5dcb0 __strlcpy_chk + 85
7   telescope                     	0x0000000100c644ae load_gemini_url + 106
8   telescope                     	0x0000000100c6384e do_load_url + 442
9   telescope                     	0x0000000100c635a1 load_url + 64
10  telescope                     	0x0000000100c65ded ui_main_loop + 19
11  telescope                     	0x0000000100c63f77 main + 1038
12  libdyld.dylib                 	0x00007fff70e8d015 start + 1
```