### PR TITLE
provide HOSTCC and HOSTCFLAGS variables to simplify cross-compilation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,9 @@ telescope_SOURCES +=	phos/phos.h	\
 noinst_PROGRAMS =	pagebundler
 pagebundler_SOURCES =	pagebundler.c
 
+pagebundler$(EXEEXT): pagebundler.c
+	$(HOSTCC) $(HOSTCFLAGS) -o $@ pagebundler.c
+
 BUILT_SOURCES =		cmd.gen.c compile_flags.txt emoji-matcher.c pages.c
 
 CLEANFILES =		cmd.gen.c compile_flags.txt emoji-matcher.c pages.c \

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,12 @@ AC_PROG_YACC
 
 PKG_PROG_PKG_CONFIG
 
+AC_ARG_VAR(HOSTCC, [The C compiler on the host.])
+AC_ARG_VAR(HOSTCFLAGS, [CFLAGS for the host compiler])
+
+test -z "${HOSTCC}"     && HOSTCC='$(CC)'
+test -z "${HOSTCFLAGS}" && HOSTCFLAGS='$(CFLAGS)'
+
 AC_ARG_WITH([libimsg],
 	AS_HELP_STRING([--with-libimsg],
 		[Build with imsg-compat library (default: disabled)]))


### PR DESCRIPTION
pagebundler is a helper that needs to be built with the *host* compiler
because it's used to generate some sources.  In normal situations,
HOSTCC and HOSTCFLAGS are just ${CC} and ${CFLAGS}, but folks that
cross-compile can specify there the host compiler and flags to
successfully build telescope.

The idea is largely based on what gforth does: it re-uses ${CFLAGS} for
the host compiler though, while I'm adding an extra variable for that.

fixes #5 