### PR TITLE
A few MacOS fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ AC_MSG_NOTICE([Using default-editor: $DEFAULT_EDITOR])
 AC_DEFINE_UNQUOTED([DEFAULT_EDITOR], ["$DEFAULT_EDITOR"], [The default editor])
 
 DEFAULT_OPENER=xdg-open
-AS_IF([test "x$platform" = "xdarwin"], [
+AS_IF([test "x$PLATFORM" = "xdarwin"], [
 	DEFAULT_OPENER=open
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,14 @@ AS_IF([test "x$with_libbsd" = "xyes"], [
 if test "x$PLATFORM" = "xdarwin"; then
 	export LDFLAGS="-L/opt/homebrew/opt/libressl/lib $LDFLAGS"
 	export CPPFLAGS="-I/opt/homebrew/opt/libressl/include $CPPFLAGS"
-	export PKG_CONFIG_PATH="/opt/homebrew/opt/libressl/lib/pkgconfig $PKG_CONFIG_PATH"
+
+	# This is not neat at all -- but if homebrew is used, it's often up to
+	# the user to define PKG_CONFIG_PATH in the environment.
+	# Some CI systems don't do this, so we'll have to.
+	AC_MSG_NOTICE([Setting PKG_CONFIG_PATH programatically])
+	export PKG_CONFIG_PATH="$(find ${HOMEBREW_PREFIX}/Cellar \
+				 -name 'pkgconfig' -type d | \
+				 tr '\n' ':' | sed s/.$//):$PKG_CONFIG_PATH"
 fi
 
 AC_REPLACE_FUNCS([

--- a/mailcap.c
+++ b/mailcap.c
@@ -32,7 +32,7 @@
 #include "mailcap.h"
 #include "xwrapper.h"
 
-#define DEFAULT_MAILCAP_ENTRY "*/*; "DEFAULT_OPENER" %s"
+#define DEFAULT_MAILCAP_ENTRY "*/*; "DEFAULT_OPENER" %s; needsterminal"
 
 #define str_unappend(ch) if (sps.off > 0 && (ch) != EOF) { sps.off--; }
 


### PR DESCRIPTION
Hey,

These are a few commits to improve using telescope on MacOS.

I don't think there's anything too controversial here... I know the PKG_CONFIG_PATH change sucks, but it seems to be the best solution of a bad bunch, and in my testing, didn't cause any negative issues.

The change to add `needsterminal` to the DEFAULT_MAILCAP_ENTRY seems fine to me, and makes things a little easier.  This change isn't MacOS specific, mind you...